### PR TITLE
lazy-init-fix —Lazy initialization implementation of AdminClient to prevent conflict with Spring's JaasLoginModule.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,22 @@ that aims to provide a simple way of getting health-check functionality for your
 It was inspired by existent functionalities present in the [Spring Cloud Stream](https://spring.io/projects/spring-cloud-stream) project.
 
 ## Dependency
-It is available both on JitPack's and on Maven Central.
+
+Maven Central
 ```maven
 <dependency>
   <groupId>io.github.leofuso</groupId>
   <artifactId>actuator-kafka</artifactId>
-  <version>v2.7.0.RELEASE</version>
+  <version>v2.7.0.2.RELEASE</version>
+</dependency>
+``` 
+
+JitPack
+```maven
+<dependency>
+  <groupId>com.github.leofuso</groupId>
+  <artifactId>actuator-kafka</artifactId>
+  <version>v2.7.0.2.RELEASE</version>
 </dependency>
 ``` 
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = 'io.github.leofuso'
-version = 'v2.7.0.1-SNAPSHOT'
+version = 'v2.7.0.2-SNAPSHOT'
 
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = 'io.github.leofuso'
-version = 'v2.7.0.2-SNAPSHOT'
+version = 'v2.7.0.2.RELEASE'
 
 
 repositories {


### PR DESCRIPTION
Lazy initialization implementation of AdminClient to prevent conflict with Spring's JaasLoginModule.